### PR TITLE
Honor some env var on startup

### DIFF
--- a/vars/default
+++ b/vars/default
@@ -2,8 +2,8 @@
 
 # Global vars
 
-# Kubernetes version to install
-KUBERNETES_VERSION="v1.4.3"
+# Kubernetes version to install, Default: v1.4.3. Overrideable
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.4.3}
 
 # Docker
 DOCKER="/usr/bin/docker"
@@ -22,7 +22,7 @@ KUBECTL="/usr/bin/kubectl"
 
 # etcd settings
 ETCD_NAME="etcd"
-ETCD_VERSION="v2.3.7"
+ETCD_VERSION=${ETCD_VERSION:-v2.3.7}
 ETCD_CLIENT_PORT="2379"
 ETCD_PEER_PORT="2380"
 ETCD_IMAGE="quay.io/coreos/etcd:${ETCD_VERSION}"
@@ -32,10 +32,11 @@ ETCD_PEER_SERVERS="http://127.0.0.1:$ETCD_PEER_PORT"     # Server endpoints for 
 # flannel settings
 FLANNEL="/usr/bin/flanneld"
 FLANNEL_ENV="/run/flannel/subnet.env"
-FLANNEL_VERSION="0.6.1"
+FLANNEL_VERSION=${FLANNEL_VERSION:-0.6.1}
 
 # Master network config
-PRIVATE_MASTER_IF=eth1
+# Private master interface. Default: eth1, overridable
+PRIVATE_MASTER_IF=${PRIVATE_MASTER_IF:-eth1}
 PRIVATE_MASTER_HOST="$(ip -4 a s $PRIVATE_MASTER_IF | grep inet | awk '{print $2}' | cut -f1 -d"/")"
 
 # Node network config


### PR DESCRIPTION
Allow environmental variables to override Nanokube startup. For
example, to use Kubernetes v1.4.7, you can invoke:

KUBERNETES_VERSION=v1.4.7 ./nanokube -s

The following will now accept environmental values from the
command line:

KUBERNETES_VERSION
ETCD_VERSION
FLANNEL_VERSION
PRIVATE_MASTER_IF

Reasoning and Use-case:

I am using Nanokube for a custom dev vm. For various reasons, we cannot use Minkube, so we are baking Nanokube along with other tools into a Vagrant box. Since we are using Ubuntu 16, we
don't have network interfaces such as `eth1`. Being able to pass the interface to look at is
helpful.

I also want to specify the Kubernetes version. I can keep sending updates or maintain our own fork, but being able to change component versions through parameterization is probably a better idea.